### PR TITLE
Revert "Fix #17: Set correct gazebo lidar scan topic in bridge"

### DIFF
--- a/config/gazebo_bridge.yaml
+++ b/config/gazebo_bridge.yaml
@@ -7,7 +7,7 @@
 
 # Bridge lidar
 - ros_topic_name: "lidar/scan"
-  gz_topic_name: "scan"
+  gz_topic_name: "lidar/scan"
   ros_type_name: "sensor_msgs/msg/LaserScan"
   gz_type_name: "gz.msgs.LaserScan"
   direction: GZ_TO_ROS


### PR DESCRIPTION
Reverts csun-arcs/arcs_cohort_gazebo_sim#18